### PR TITLE
Change `Cache-Control` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ class SseStream extends Stream.Transform {
       destination.writeHead(200, {
         'Content-Type': 'text/event-stream; charset=utf-8',
         'Transfer-Encoding': 'identity',
-        'Cache-Control': 'no-cache',
+        'Cache-Control': 'no-transform',
         Connection: 'keep-alive',
       })
       destination.flushHeaders()


### PR DESCRIPTION
This is needed for proxies that interfere with the request (such as caching). This was the case with the `create-react-app`, when proxying requests to the dev-server backend to your real backend. See this issue: https://github.com/facebook/create-react-app/issues/1633#issuecomment-291353470 . Maybe this header isn't always desired, but I didn't know a good way to make this configurable other than passing a 3rd argument to this `pipe` function, or maybe an extra parameter to the constructor allowing users to overwrite some of these headers if they want.