### PR TITLE
feat: replace/extend default HTTP headers with custom ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ In a `(req, res)` handler for a [`request`](https://nodejs.org/api/http.html#htt
 
 ```javascript
 const SseStream = require('ssestream')
+const customHeaders = {'Cache-Control': 'no-cache, no-transform'} // optional
 
 function (req, res) {
   const sse = new SseStream(req)
-  sse.pipe(res)
+  sse.pipe(res, undefined, customHeaders)
   
   const message = {
     data: 'hello\nworld',

--- a/index.js
+++ b/index.js
@@ -30,14 +30,25 @@ class SseStream extends Stream.Transform {
     }
   }
 
-  pipe(destination, options) {
+  /**
+   * Similar to {@link Stream.Transform.push} with the addition of specifying custom HTTP headers.
+   */
+  pipe(destination, options, customHeaders) {
     if (typeof destination.writeHead === 'function') {
-      destination.writeHead(200, {
+      var defaultHeaders = {
         'Content-Type': 'text/event-stream; charset=utf-8',
         'Transfer-Encoding': 'identity',
         'Cache-Control': 'no-cache',
         Connection: 'keep-alive',
-      })
+      }
+
+      // replace/extend default headers
+      if (customHeaders) {
+        for (const header of Object.keys(customHeaders)) {
+          defaultHeaders[header] = customHeaders[header]
+        }
+      }
+      destination.writeHead(200, defaultHeaders)
       destination.flushHeaders()
     }
     // Some clients (Safari) don't trigger onopen until the first frame is received.

--- a/test/ssestream_test.js
+++ b/test/ssestream_test.js
@@ -103,6 +103,26 @@ data: hello
     sse.pipe(sink)
   })
 
+
+  it('extends and replaces default headers with custom ones', callback => {
+    sink.writeHead = (status, headers) => {
+      assert.deepEqual(headers, {
+        'Content-Type': 'text/event-stream; charset=utf-8',
+        'Transfer-Encoding': 'identity',
+        // 'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+        'Cache-Control': 'no-cache, no-transform', // replace existing header
+        'Custom-Header': 'foo' // add custom header
+      })
+      callback()
+    }
+    const customHeaders = {
+      'Cache-Control': 'no-cache, no-transform', // replace existing header
+      'Custom-Header': 'foo' // add custom header
+    }
+    sse.pipe(sink, undefined, customHeaders)
+  })
+
   it('allows an eventsource to connect', callback => {
     const server = http.createServer((req, res) => {
       sse = new SseStream(req)


### PR DESCRIPTION
Added a new (optional) argument to the `pipe()` function that adds the ability to replace the default HTTP headers for the request, or add custom ones.

Includes additional test and updated README.md.

This covers the use-case for https://github.com/EventSource/node-ssestream/pull/1. However, my PR adds this functionality using a new argument, i.e. it's not a breaking change.

In the meantime, my modified version is published as "@tillhub/node-ssestream": https://www.npmjs.com/package/@tillhub/node-ssestream